### PR TITLE
fix: Do not use comment in JSON (v0.1.1)

### DIFF
--- a/helm-chart/kappnav/templates/configmaps/configmap.action.deployment.yaml
+++ b/helm-chart/kappnav/templates/configmaps/configmap.action.deployment.yaml
@@ -28,7 +28,7 @@ data:
         "text.nls":"action.url.deployment.replicas.text", 
         "description":"View Deployment replicas", 
         "description.nls":"action.url.deployment.replicas.desc", 
-        # do not use / before project otherwise it will have // as openshift console url end with / already
+        "url-pattern-comment":"# do not use / before k8s otherwise it will have // as openshift console url end with / already",
         "url-pattern":"${builtin.openshift-console-url}project/${resource.$.metadata.namespace}/browse/deployment/${resource.$.metadata.name}", 
         "open-window": "current", 
         "menu-item": "true" 

--- a/helm-chart/kappnav/templates/configmaps/configmap.action.job.yaml
+++ b/helm-chart/kappnav/templates/configmaps/configmap.action.job.yaml
@@ -31,7 +31,7 @@ data:
 {{ if eq .Values.env.kubeEnv "minikube" }}
         "url-pattern":"${builtin.openshift-console-url}/job/${resource.$.metadata.namespace}/${resource.$.metadata.name}?namespace=${resource.$.metadata.namespace}", 
 {{ else if or (eq .Values.env.kubeEnv "okd") (eq .Values.env.kubeEnv "ocp") }} 
-        # do not use / before k8s otherwise it will have // as openshift console url end with / already
+        "url-pattern-comment":"# do not use / before k8s otherwise it will have // as openshift console url end with / already",
         "url-pattern":"${builtin.openshift-admin-console-url}k8s/ns/${resource.$.metadata.namespace}/jobs/${resource.$.metadata.name}", 
 {{ end }}
         "open-window": "current", 

--- a/helm-chart/kappnav/templates/configmaps/configmap.action.pod.yaml
+++ b/helm-chart/kappnav/templates/configmaps/configmap.action.pod.yaml
@@ -30,7 +30,7 @@ data:
 {{ if eq .Values.env.kubeEnv "minikube" }}
         "url-pattern":"${builtin.openshift-console-url}/pod/${resource.$.metadata.namespace}/${resource.$.metadata.name}?namespace=${resource.$.metadata.namespace}", 
 {{ else if eq .Values.env.kubeEnv "minishift" }}
-        # do not use / before project otherwise it will have // as openshift console url end with / already
+        "url-pattern-comment":"# do not use / before k8s otherwise it will have // as openshift console url end with / already",
         "url-pattern":"${builtin.openshift-console-url}project/${resource.$.metadata.namespace}/browse/pods/${resource.$.metadata.name}",
 {{ else if or (eq .Values.env.kubeEnv "okd") (eq .Values.env.kubeEnv "ocp") }} 
         # do not use / before k8s otherwise it will have // as openshift console url end with / already

--- a/helm-chart/kappnav/templates/configmaps/configmap.action.route.yaml
+++ b/helm-chart/kappnav/templates/configmaps/configmap.action.route.yaml
@@ -28,7 +28,7 @@ data:
         "description":"View Routes detail",
         "description.nls":"action.url.routes.detail.desc",
 {{ if or (eq .Values.env.kubeEnv "minishift") }} 
-      # do not use / before project otherwise it will have // as openshift console url end with / already
+      "url-pattern-comment":"# do not use / before k8s otherwise it will have // as openshift console url end with / already",
       "url-pattern":"${builtin.openshift-console-url}project/${resource.$.metadata.namespace}/browse/routes/${resource.$.metadata.name}",    
 {{ else if or (eq .Values.env.kubeEnv "okd") (eq .Values.env.kubeEnv "ocp") }} 
       # do not use / before k8s otherwise it will have // as openshift console url end with / already

--- a/helm-chart/kappnav/templates/configmaps/configmap.action.service.yaml
+++ b/helm-chart/kappnav/templates/configmaps/configmap.action.service.yaml
@@ -30,7 +30,7 @@ data:
 {{ if eq .Values.env.kubeEnv "minikube" }}
         "url-pattern":"${builtin.openshift-console-url}/service/${resource.$.metadata.namespace}/${resource.$.metadata.name}?namespace=${resource.$.metadata.namespace}", 
 {{ else if eq .Values.env.kubeEnv "minishift" }}
-        # do not use / before project otherwise it will have // as openshift console url end with / already
+        "url-pattern-comment":"# do not use / before k8s otherwise it will have // as openshift console url end with / already",
         "url-pattern":"${builtin.openshift-console-url}project/${resource.$.metadata.namespace}/browse/services/${resource.$.metadata.name}",
 {{ else if or (eq .Values.env.kubeEnv "okd") (eq .Values.env.kubeEnv "ocp") }} 
         # do not use / before k8s otherwise it will have // as openshift console url end with / already


### PR DESCRIPTION
Related to #15.  Fix also needs to be in `v0.1.1`

- This fix is for kappnav/ui#22
- The UI code is converting the content of the YAML file into JSON.
Since there is no support for comments in JSON, the # in the YAML is
causing the JSON parser to fail.