### PR TITLE
minimize specified resource requirements

### DIFF
--- a/kappnav.yaml
+++ b/kappnav.yaml
@@ -128,8 +128,8 @@ spec:
       constraints:
         enabled: false
       requests:
-        cpu: 500m
-        memory: 512Mi
+        cpu: 10m
+        memory: 256Mi
       limits:
         cpu: 500m
         memory: 512Mi
@@ -145,8 +145,8 @@ spec:
       constraints:
         enabled: false
       requests:
-        cpu: 500m
-        memory: 512Mi
+        cpu: 10m
+        memory: 16Mi
       limits:
         cpu: 500m
         memory: 512Mi
@@ -164,8 +164,8 @@ spec:
       constraints:
         enabled: false
       requests:
-        cpu: 500m
-        memory: 512Mi
+        cpu: 50m
+        memory: 64Mi
       limits:
         cpu: 500m
         memory: 512Mi
@@ -182,8 +182,8 @@ spec:
       constraints:
         enabled: false
       requests:
-        cpu: 500m
-        memory: 512Mi
+        cpu: 10m
+        memory: 128Mi
       limits:
         cpu: 500m
         memory: 512Mi


### PR DESCRIPTION
Specify smallest possible resource requirements for scheduling.  Values were chosen from bringup and light usage,  choosing:

memory - observed working set 
cpu - highest observed value 

All values were observed using 'docker stats'.  