### PR TITLE
Use latest base image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # imitations under the License.
 ###########################################################################
-FROM quay.io/operator-framework/helm-operator:v0.8.0
+FROM quay.io/operator-framework/helm-operator
 
 ARG VERSION
 ARG BUILD_DATE


### PR DESCRIPTION
Remove Dockerfile's reference to a specific tag of the base image.