### PR TITLE
Update oauth-proxy to version 4.3.0 in quay.io

### DIFF
--- a/helm-chart/kappnav/templates/deploy.ui.yaml
+++ b/helm-chart/kappnav/templates/deploy.ui.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
 {{ if ne .Values.env.kubeEnv "minikube" }} 
       - name: oauth-proxy
-        image: openshift/oauth-proxy:v1.1.0
+        image: quay.io/openshift/origin-oauth-proxy:4.3.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8443


### PR DESCRIPTION
The openshift/ouath-proxy repo has moved from dockerhub to quay.io.  The older version of oauth-proxy is not compatible with openshift 4.2. Upgrade the ouath-proxy.