### PR TITLE
kam owner support

### DIFF
--- a/deploy/crds/actions_v1_kindactionmapping_crd.yaml
+++ b/deploy/crds/actions_v1_kindactionmapping_crd.yaml
@@ -9,6 +9,9 @@ spec:
     listKind: KindActionMappingList
     plural: kindactionmappings
     singular: kindactionmapping
+    shortNames:
+    - kam
+    - kams
   scope: Namespaced
   subresources:
     status: {}
@@ -33,6 +36,10 @@ spec:
               items:
                 properties:
                   apiVersion:
+                    type: string
+                  owner:
+                    type: string
+                  ownerUID:
                     type: string
                   kind:
                     type: string

--- a/deploy/crds/actions_v1_kindactionmapping_crd.yaml
+++ b/deploy/crds/actions_v1_kindactionmapping_crd.yaml
@@ -41,6 +41,8 @@ spec:
                     type: string
                   ownerUID:
                     type: string
+                  ownerAPI: 
+                    type: string
                   kind:
                     type: string
                   mapname:

--- a/pkg/apis/actions/v1/kindactionmapping_types.go
+++ b/pkg/apis/actions/v1/kindactionmapping_types.go
@@ -17,9 +17,12 @@ type KindActionMappingSpec struct {
 	Mappings   []MappingConfiguration `json:"mappings,omitempty"`
 }
 
-// MappingsConfigurtion defines resource constraints for Mapping configuration
+// MappingConfiguration defines resource constraints for Mapping configuration
 type MappingConfiguration struct {
-	ApiVersion string `json:"apiVersion,omitempty"`
+	APIVersion string `json:"apiVersion,omitempty"`
+	Owner      string `json:"owner,omitempty"`
+	OwnerUID   string `json:"ownerUID,omitempty"`
+	OwnerAPI   string `json:"ownerAPI,omitempty"`
 	Kind       string `json:"kind,omitempty"`
 	Subkind    string `json:"subkind,omitempty"`
 	Name       string `json:"name,omitempty"`


### PR DESCRIPTION
Add optional owner, ownerUID, and owerAPI fields to KindActionMapping mappings.  When specified, resource matches a KAM if and only if resource has a matching ownerRef. 