### PR TITLE
Expose the View Details action to the UI

### DIFF
--- a/deploy/maps/action/configmap.action.deployment.yaml
+++ b/deploy/maps/action/configmap.action.deployment.yaml
@@ -89,6 +89,6 @@ data:
         "url-pattern":"${builtin.openshift-console-url}/deployment/${resource.$.metadata.namespace}/${resource.$.metadata.name}?namespace=${resource.$.metadata.namespace}",
 {{ end }}
         "open-window": "current", 
-        "menu-item": "false" 
+        "menu-item": "true" 
       }
     ]

--- a/deploy/maps/action/configmap.action.deploymentconfig.yaml
+++ b/deploy/maps/action/configmap.action.deploymentconfig.yaml
@@ -33,6 +33,6 @@ data:
         "url-pattern":"",
 {{ end }}
         "open-window": "current", 
-        "menu-item": "false" 
+        "menu-item": "true" 
       }
     ]

--- a/deploy/maps/action/configmap.action.ingress.yaml
+++ b/deploy/maps/action/configmap.action.ingress.yaml
@@ -34,7 +34,7 @@ data:
         "url-pattern":"${builtin.openshift-admin-console-url}/k8s/ns/${resource.$.metadata.namespace}/ingresses/${resource.$.metadata.name}",
 {{ end }}
         "open-window": "current", 
-        "menu-item": "false" 
+        "menu-item": "true" 
       }
 {{ end }}
     ]

--- a/deploy/maps/action/configmap.action.job.yaml
+++ b/deploy/maps/action/configmap.action.job.yaml
@@ -34,7 +34,7 @@ data:
         "url-pattern":"${builtin.openshift-admin-console-url}/k8s/ns/${resource.$.metadata.namespace}/jobs/${resource.$.metadata.name}", 
 {{ end }}
         "open-window": "current", 
-        "menu-item": "false" 
+        "menu-item": "true" 
       },
 {{ end }}
       {

--- a/deploy/maps/action/configmap.action.pod.yaml
+++ b/deploy/maps/action/configmap.action.pod.yaml
@@ -35,7 +35,7 @@ data:
         "url-pattern":"${builtin.openshift-admin-console-url}/k8s/ns/${resource.$.metadata.namespace}/pods/${resource.$.metadata.name}",
 {{ end }}
         "open-window": "current", 
-        "menu-item": "false" 
+        "menu-item": "true" 
       }
     ]
   snippets: |

--- a/deploy/maps/action/configmap.action.route.yaml
+++ b/deploy/maps/action/configmap.action.route.yaml
@@ -33,6 +33,6 @@ data:
       "url-pattern":"${builtin.openshift-admin-console-url}/k8s/ns/${resource.$.metadata.namespace}/routes/${resource.$.metadata.name}",         
 {{ end }}
         "open-window": "current", 
-        "menu-item": "false" 
+        "menu-item": "true" 
       }
     ]

--- a/deploy/maps/action/configmap.action.service.yaml
+++ b/deploy/maps/action/configmap.action.service.yaml
@@ -97,6 +97,6 @@ data:
         "url-pattern":"${builtin.openshift-admin-console-url}/k8s/ns/${resource.$.metadata.namespace}/services/${resource.$.metadata.name}",
 {{ end }}
         "open-window": "current", 
-        "menu-item": "false" 
+        "menu-item": "true" 
       }
     ]


### PR DESCRIPTION
In the new UI, there are flows where the user does not have a link to take them to the appropriate OpenShift console page to view more details about a particular Kubernetes object.  In the past UI, the name of each resource was the link to OpenShift, but now most names take users to the Labels and Annotations page.  The Labels and Annotations page needs the `View Detail` action exposed so users can go to OpenShift to see more than just the Labels/Annotations.

